### PR TITLE
Use environment port variable for server

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,6 +16,6 @@ app.use('/api/login/', loginRouters);
 //Porting and listening
 const PORT = process.env.PORT || 3000;
 
-app.listen(3000, () => {
+app.listen(PORT, () => {
   console.log(`Servidor escuchando en http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- allow configuration via `PORT` when starting Express

## Testing
- `PORT=4000 node app.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a3afc0f320832680dd614dbb42b7e5