### PR TITLE
Add input validation and document API format requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# API Usage
+
+## Requisitos de formato
+
+- **Email**: debe cumplir con el formato `usuario@dominio.tld`.
+- **Contraseña**: mínimo 8 caracteres.
+- **Roles permitidos**: `admin`, `user` (por defecto `user`).
+
+## Endpoints relevantes
+
+### POST /api/customers/
+Crea un nuevo usuario.
+
+```json
+{
+  "name": "Nombre",
+  "email": "correo@ejemplo.com",
+  "password": "contraseñaSegura",
+  "role": "user"
+}
+```
+
+### POST /api/login/
+Autentica a un usuario existente.
+
+```json
+{
+  "email": "correo@ejemplo.com",
+  "password": "contraseñaSegura"
+}
+```

--- a/middleware/validators.js
+++ b/middleware/validators.js
@@ -1,0 +1,5 @@
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const ALLOWED_ROLES = ['admin', 'user'];
+const MIN_PASSWORD_LENGTH = 8;
+
+module.exports = { EMAIL_REGEX, ALLOWED_ROLES, MIN_PASSWORD_LENGTH };

--- a/routers/customers.js
+++ b/routers/customers.js
@@ -3,6 +3,11 @@ const bcrypt = require('bcrypt');
 const { auth } = require('../middleware/auth.js');
 const { pool } = require('../database/pool.js');
 const { ApiError, asyncHandler } = require('../middleware/errors.js');
+const {
+  EMAIL_REGEX,
+  ALLOWED_ROLES,
+  MIN_PASSWORD_LENGTH,
+} = require('../middleware/validators.js');
 
 const customerRouters = express.Router();
 
@@ -85,6 +90,22 @@ customerRouters.post(
       trimRole === ''
     ) {
       throw new ApiError(400, 'VALIDATION_ERROR', 'Datos vacios.');
+    }
+
+    if (!EMAIL_REGEX.test(trimEmail)) {
+      throw new ApiError(400, 'VALIDATION_ERROR', 'Email invalido.');
+    }
+
+    if (trimPassword.length < MIN_PASSWORD_LENGTH) {
+      throw new ApiError(
+        400,
+        'VALIDATION_ERROR',
+        `La contraseña debe tener al menos ${MIN_PASSWORD_LENGTH} caracteres.`
+      );
+    }
+
+    if (!ALLOWED_ROLES.includes(trimRole)) {
+      throw new ApiError(400, 'VALIDATION_ERROR', 'Rol invalido.');
     }
 
     const password_hash = await bcrypt.hash(

--- a/routers/login.js
+++ b/routers/login.js
@@ -3,6 +3,7 @@ const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
 const { pool } = require('../database/pool.js');
 const { ApiError, asyncHandler } = require('../middleware/errors.js');
+const { EMAIL_REGEX, MIN_PASSWORD_LENGTH } = require('../middleware/validators.js');
 
 const loginRouters = express.Router();
 
@@ -21,6 +22,18 @@ loginRouters.post(
 
     if (trimEmail === '' || trimPassword === '') {
       throw new ApiError(400, 'VALIDATION_ERROR', 'Datos del body vacios');
+    }
+
+    if (!EMAIL_REGEX.test(trimEmail)) {
+      throw new ApiError(400, 'VALIDATION_ERROR', 'Email invalido.');
+    }
+
+    if (trimPassword.length < MIN_PASSWORD_LENGTH) {
+      throw new ApiError(
+        400,
+        'VALIDATION_ERROR',
+        `La contraseña debe tener al menos ${MIN_PASSWORD_LENGTH} caracteres.`
+      );
     }
 
     const result = await pool.query(


### PR DESCRIPTION
## Summary
- Validate email format, password length, and allowed roles when creating users
- Apply same email and password validation to login endpoint
- Document email, password, and role requirements in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a3f4a4e1c48326937386e3e12c0e13