### PR TITLE
Fix rate limiter option names

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,9 +17,9 @@ app.use(helmet());
 
 app.use(
   rateLimit({
-    windowsMs: 15 * 60 * 1000,
+    windowMs: 15 * 60 * 1000,
     max: 300,
-    standartHeaders: true,
+    standardHeaders: true,
     legacyHeaders: false,
   })
 );


### PR DESCRIPTION
## Summary
- Fix typos in rate limiter configuration to use `windowMs` and `standardHeaders`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a634d2339c83269743426fcf40520e