### PR TITLE
Fix customer update email trimming and empty body validation

### DIFF
--- a/routers/customers.js
+++ b/routers/customers.js
@@ -75,7 +75,7 @@ customerRouters.patch(
     }
 
     if (body.email !== undefined) {
-      const trimEmail = body.name.trim().toLowerCase();
+      const trimEmail = body.email.trim().toLowerCase();
       newEmail = trimEmail;
     }
 
@@ -89,8 +89,8 @@ customerRouters.patch(
 
     if (
       body.name == undefined &&
-      body.price == undefined &&
-      body.stock == undefined
+      body.email == undefined &&
+      body.password == undefined
     ) {
       throw new ApiError(400, 'VALIDATION_ERROR', 'Body vacio.');
     }


### PR DESCRIPTION
## Summary
- trim incoming email properly when updating customer
- validate empty body fields for name, email and password

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a635287f608326ba53f886dd3f4bb7