### PR TITLE
fix: validate params object in product route

### DIFF
--- a/routers/products.js
+++ b/routers/products.js
@@ -23,7 +23,7 @@ productsRouters.get(
 productsRouters.get(
   '/:id',
   asyncHandler(async (req, res) => {
-    const { error, value } = idScheme.validate(req.params.id);
+    const { error, value } = idScheme.validate(req.params);
 
     if (error) {
       throw new ApiError(400, 'VALIDATION_ERROR', error.details[0].message);


### PR DESCRIPTION
## Summary
- fix GET /:id product route to validate the params object and extract id

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a6353bc0208326a70d993b54e0a7ba