### PR TITLE
Add supertest tests for authentication, products, and orders

### DIFF
--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -1,0 +1,63 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.BCRYPT_SALT = '1';
+
+const request = require('supertest');
+const app = require('../app');
+const { createUser } = require('../testUtils');
+
+describe('Authentication and protected routes', () => {
+  it('registers a new user', async () => {
+    const email = `new${Date.now()}@test.com`;
+    const res = await request(app)
+      .post('/api/login/signup')
+      .send({ name: 'Test', email, password: 'password123', role: 'user' });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('email', email.toLowerCase());
+  });
+
+  it('logs in an existing user', async () => {
+    const email = `login${Date.now()}@test.com`;
+    await request(app)
+      .post('/api/login/signup')
+      .send({ name: 'Login', email, password: 'password123', role: 'user' });
+
+    const res = await request(app)
+      .post('/api/login/')
+      .send({ email, password: 'password123' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('token');
+    expect(res.body).toHaveProperty('user');
+  });
+
+  describe('protected customer routes', () => {
+    let admin;
+    let user;
+
+    beforeAll(async () => {
+      admin = await createUser('admin');
+      user = await createUser('user');
+    });
+
+    it('denies access without token', async () => {
+      const res = await request(app).get('/api/customers/');
+      expect(res.status).toBe(401);
+    });
+
+    it('denies access to non-admin users', async () => {
+      const res = await request(app)
+        .get('/api/customers/')
+        .set('Authorization', `Bearer ${user.token}`);
+      expect(res.status).toBe(403);
+    });
+
+    it('allows admin users', async () => {
+      const res = await request(app)
+        .get('/api/customers/')
+        .set('Authorization', `Bearer ${admin.token}`);
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+  });
+});

--- a/__tests__/orders.test.js
+++ b/__tests__/orders.test.js
@@ -1,0 +1,62 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.BCRYPT_SALT = '1';
+
+const request = require('supertest');
+const app = require('../app');
+const { createUser } = require('../testUtils');
+
+describe('Order operations', () => {
+  let admin;
+  let user;
+  let productId;
+  let orderId;
+
+  beforeAll(async () => {
+    admin = await createUser('admin');
+    user = await createUser('user');
+
+    // create product to order
+    const name = `OrderProduct-${Date.now()}`;
+    await request(app)
+      .post('/api/products/')
+      .set('Authorization', `Bearer ${admin.token}`)
+      .send({ name, price: 15, stock: 5 });
+    const listRes = await request(app).get('/api/products/');
+    const created = listRes.body.find((p) => p.name === name);
+    productId = created.id;
+  });
+
+  it('allows admin to create an order', async () => {
+    const res = await request(app)
+      .post('/api/orders/')
+      .set('Authorization', `Bearer ${admin.token}`)
+      .send({ product_id: productId, amount: 1, customer_id: user.id });
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('amount', 1);
+    orderId = res.body.id;
+  });
+
+  it('updates order to paid', async () => {
+    const res = await request(app)
+      .patch(`/api/orders/${orderId}`)
+      .set('Authorization', `Bearer ${admin.token}`);
+    expect(res.status).toBe(200);
+  });
+
+  it('prevents non-admin from creating orders', async () => {
+    const res = await request(app)
+      .post('/api/orders/')
+      .set('Authorization', `Bearer ${user.token}`)
+      .send({ product_id: productId, amount: 1, customer_id: user.id });
+    expect(res.status).toBe(403);
+  });
+
+  it('fails when stock is insufficient', async () => {
+    const res = await request(app)
+      .post('/api/orders/')
+      .set('Authorization', `Bearer ${admin.token}`)
+      .send({ product_id: productId, amount: 999, customer_id: user.id });
+    expect(res.status).toBe(409);
+    expect(res.body).toHaveProperty('error.code', 'INSUFFICIENT_STOCK');
+  });
+});

--- a/__tests__/products.test.js
+++ b/__tests__/products.test.js
@@ -1,0 +1,75 @@
+process.env.JWT_SECRET = 'testsecret';
+process.env.BCRYPT_SALT = '1';
+
+const request = require('supertest');
+const app = require('../app');
+const { createUser } = require('../testUtils');
+
+describe('Product operations', () => {
+  let admin;
+  let user;
+  let productId;
+
+  beforeAll(async () => {
+    admin = await createUser('admin');
+    user = await createUser('user');
+  });
+
+  it('allows admin to create a product', async () => {
+    const name = `Product-${Date.now()}`;
+    const res = await request(app)
+      .post('/api/products/')
+      .set('Authorization', `Bearer ${admin.token}`)
+      .send({ name, price: 10, stock: 5 });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('name', name);
+
+    // Fetch product list to get id
+    const listRes = await request(app).get('/api/products/');
+    const created = listRes.body.find((p) => p.name === name);
+    productId = created.id;
+  });
+
+  it('rejects product creation with invalid data', async () => {
+    const res = await request(app)
+      .post('/api/products/')
+      .set('Authorization', `Bearer ${admin.token}`)
+      .send({ price: 10, stock: 5 });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('prevents non-admin from creating products', async () => {
+    const res = await request(app)
+      .post('/api/products/')
+      .set('Authorization', `Bearer ${user.token}`)
+      .send({ name: 'Nope', price: 10, stock: 5 });
+    expect(res.status).toBe(403);
+  });
+
+  it('allows admin to update a product', async () => {
+    const res = await request(app)
+      .patch(`/api/products/${productId}`)
+      .set('Authorization', `Bearer ${admin.token}`)
+      .send({ price: 20 });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('price');
+  });
+
+  it('returns 404 for updating non-existent product', async () => {
+    const res = await request(app)
+      .patch('/api/products/999999')
+      .set('Authorization', `Bearer ${admin.token}`)
+      .send({ price: 10 });
+    expect(res.status).toBe(404);
+  });
+
+  it('prevents non-admin from updating products', async () => {
+    const res = await request(app)
+      .patch(`/api/products/${productId}`)
+      .set('Authorization', `Bearer ${user.token}`)
+      .send({ price: 30 });
+    expect(res.status).toBe(403);
+  });
+});

--- a/testUtils.js
+++ b/testUtils.js
@@ -1,0 +1,26 @@
+const request = require('supertest');
+const app = require('./app');
+
+async function createUser(role = 'user') {
+  const timestamp = Date.now();
+  const email = `${role}${timestamp}@test.com`;
+  const password = 'password123';
+  const name = role === 'admin' ? 'Admin' : 'User';
+
+  const signupRes = await request(app)
+    .post('/api/login/signup')
+    .send({ name, email, password, role });
+
+  const loginRes = await request(app)
+    .post('/api/login/')
+    .send({ email, password });
+
+  return {
+    id: signupRes.body.id,
+    token: loginRes.body.token,
+    email,
+    password,
+  };
+}
+
+module.exports = { createUser };


### PR DESCRIPTION
## Summary
- add tests for user signup, login, and role-protected customer routes
- cover product creation, updates, and validation/authorization errors
- verify order creation, payment updates, and insufficient stock handling

## Testing
- `npm test` *(fails: Cannot connect to database/500 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68abd0e6c0f483269c63611ddb86f895